### PR TITLE
Group label should be a string

### DIFF
--- a/blanc_basic_assets/fields.py
+++ b/blanc_basic_assets/fields.py
@@ -2,6 +2,7 @@ from itertools import groupby
 
 from django.db import models
 from django.forms.models import ModelChoiceField, ModelChoiceIterator
+from django.utils.encoding import force_text
 
 
 class GroupedModelChoiceField(ModelChoiceField):
@@ -13,7 +14,7 @@ class GroupedModelChoiceField(ModelChoiceField):
         super(GroupedModelChoiceField, self).__init__(queryset, *args, **kwargs)
         self.group_by_field = group_by_field
         if group_label is None:
-            self.group_label = lambda group: group
+            self.group_label = lambda group: force_text(group)
         else:
             self.group_label = group_label
 


### PR DESCRIPTION
Similar to: https://github.com/django/django/blob/1.11.6/django/forms/models.py#L1203

Currently the lambda just returns the object back, instead of the string of the object. This has never caused us a problem in the Django admin - however let's fix it!