### PR TITLE
Add on_delete for ForeignKeys

### DIFF
--- a/blanc_basic_assets/migrations/0001_initial.py
+++ b/blanc_basic_assets/migrations/0001_initial.py
@@ -59,11 +59,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='image',
             name='category',
-            field=models.ForeignKey(to='assets.ImageCategory'),
+            field=models.ForeignKey(to='assets.ImageCategory', on_delete=models.CASCADE),
         ),
         migrations.AddField(
             model_name='file',
             name='category',
-            field=models.ForeignKey(to='assets.FileCategory'),
+            field=models.ForeignKey(to='assets.FileCategory', on_delete=models.CASCADE),
         ),
     ]

--- a/blanc_basic_assets/models.py
+++ b/blanc_basic_assets/models.py
@@ -18,7 +18,7 @@ class ImageCategory(models.Model):
 
 @python_2_unicode_compatible
 class Image(models.Model):
-    category = models.ForeignKey(ImageCategory)
+    category = models.ForeignKey(ImageCategory, on_delete=models.CASCADE)
     title = models.CharField(max_length=100, db_index=True)
     file = models.ImageField(
         'Image', upload_to='assets/image', height_field='image_height', width_field='image_width')
@@ -49,7 +49,7 @@ class FileCategory(models.Model):
 
 @python_2_unicode_compatible
 class File(models.Model):
-    category = models.ForeignKey(FileCategory)
+    category = models.ForeignKey(FileCategory, on_delete=models.CASCADE)
     title = models.CharField(max_length=100, db_index=True)
     file = models.FileField(upload_to='assets/file')
 


### PR DESCRIPTION
Fixes the warning:

```
RemovedInDjango20Warning: on_delete will be a required arg for ForeignKey in Django 2.0. Set it to models.CASCADE on models and in existing migrations if you want to maintain the current default behavior. See https://docs.djangoproject.com/en/1.11/ref/models/fields/#django.db.models.ForeignKey.on_delete
```

To limit migrations I've edited the initial migration as this has no impact on the database.